### PR TITLE
add realname

### DIFF
--- a/abbott/pluginbase.py
+++ b/abbott/pluginbase.py
@@ -124,6 +124,7 @@ I'll create a new one for you now""")
                         'server': server,
                         'port': port,
                         'nick': nick,
+                        'realname': 'Bot operated by' + admin,
                         'channels': [channel],
                         # REMOVE is supported on freenode. I don't know about any others.
                         'remove': "freenode" in server,

--- a/abbott/plugins/irc.py
+++ b/abbott/plugins/irc.py
@@ -289,6 +289,7 @@ class IRCBotPlugin(protocol.ReconnectingClientFactory, BotPlugin):
         p.factory = self
         p.nickname = self.config['nick']
         p.password = self.config.get("password", None)
+        p.realname = self.config.get("realname", "Abbott")
         return p
 
     def broadcast_message(self, eventname, **kwargs):


### PR DESCRIPTION
This commit adds a realname parameter to the bot config, which is populated by the configuration wizard by the bot owner's name.
Previously, no realname was set, which can confuse particularly dumb clients.

Apologies for the weird repo structure; Github only allows one fork per repository.
